### PR TITLE
Dev

### DIFF
--- a/cluster_builder/config/cluster.py
+++ b/cluster_builder/config/cluster.py
@@ -121,9 +121,9 @@ class ClusterConfig:
         if "cluster_name" not in prepared_config:
             cluster_name = self.generate_random_name()
             prepared_config["cluster_name"] = cluster_name
-            logger.info(f"Creating new cluster: {cluster_name}")
+            logger.debug(f"Creating new cluster: {cluster_name}")
         else:
-            logger.info(
+            logger.debug(
                 f"Adding node to existing cluster: {prepared_config['cluster_name']}"
             )
 
@@ -136,7 +136,7 @@ class ClusterConfig:
             prepared_config["resource_name"] = f"{cloud}-{random_name}"
             logger.debug(f"Resource name: {prepared_config['resource_name']}")
         else:
-            logger.debug(f" USing provded Resource name: {prepared_config['resource_name']}")
+            logger.debug(f" Using provided Resource name: {prepared_config['resource_name']}")
 
         # Create the cluster directory
         try:

--- a/cluster_builder/templates/edge_provider.tf
+++ b/cluster_builder/templates/edge_provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+    }
+    template = {
+      source  = "hashicorp/template"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cluster-builder"
-version = "0.4.4"
+version = "0.4.5"
 description = "Swarmchestrate cluster builder"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
With this change, an edge instance can be destroyed from any node within the cluster, ensuring consistent cleanup regardless of where the destroy command is triggered.