### PR TITLE
Dev

### DIFF
--- a/cluster_builder/templates/edge/main.tf
+++ b/cluster_builder/templates/edge/main.tf
@@ -19,6 +19,9 @@ variable "cloud" {
 variable "ssh_user" {}
 variable "ssh_key" {}
 variable "ssh_auth_method" {}
+variable "ssh_port" {
+  default = 22
+}
 
 variable "k3s_token" {}
 
@@ -51,6 +54,7 @@ resource "k3s_server" "k3s" {
     host        = var.edge_device_ip
     user        = var.ssh_user
     private_key = file(var.ssh_key)
+    port        = var.ssh_port
   }
 
   config = <<-EOT
@@ -69,6 +73,7 @@ resource "k3s_server" "k3s_ha_init" {
     host        = var.edge_device_ip
     user        = var.ssh_user
     private_key = file(var.ssh_key)
+    port        = var.ssh_port
   }
 
   config = <<-EOT
@@ -90,6 +95,7 @@ resource "k3s_server" "k3s_ha_join" {
     host        = var.edge_device_ip
     user        = var.ssh_user
     private_key = file(var.ssh_key)
+    port        = var.ssh_port
   }
 
   config = <<-EOT
@@ -112,6 +118,7 @@ resource "k3s_agent" "k3s" {
     host        = var.edge_device_ip
     user        = var.ssh_user
     private_key = file(var.ssh_key)
+    port        = var.ssh_port
   }
 
   server = "https://${var.master_ip}:6443"

--- a/demo/k3s_worker_edge.json.sample
+++ b/demo/k3s_worker_edge.json.sample
@@ -4,6 +4,7 @@
     "cloud": "edge",
     "edge_device_ip": "10.0.0.1",
     "ssh_user": "your_user",
+    "ssh_port": 22,
     "ssh_auth_method": "key",  # "password" or "key"
     "ssh_key": "/path/to/key.pem",  # required if ssh_auth_method == "key"
     # "ssh_password": "your_password",  # required if ssh_auth_method == "password"

--- a/docs/config-example.md
+++ b/docs/config-example.md
@@ -88,6 +88,7 @@ config = {
     "cloud": "edge",
     "edge_device_ip": "10.0.0.1",
     "ssh_user": "your_user",
+    "ssh_port": 22,  # optional, defaults to 22
     "ssh_auth_method": "key",  # "password" or "key"
     "ssh_key": "/path/to/key.pem",  # required if ssh_auth_method == "key"
     # "ssh_password": "your_password",  # required if ssh_auth_method == "password"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cluster-builder"
-version = "0.5.0"
+version = "0.5.1"
 description = "Swarmchestrate cluster builder"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This PR adds support for custom SSH port configuration on edge nodes by introducing an optional ssh_port input (default: 22) and wiring it into edge K3s server/agent SSH auth settings. 