### PR TITLE
Dev

### DIFF
--- a/cluster_builder/swarmchestrate.py
+++ b/cluster_builder/swarmchestrate.py
@@ -863,6 +863,7 @@ class Swarmchestrate:
         master_ip: str,
         ssh_key_path: str,
         ssh_user: str,
+        ssh_port: int = 22,
     ):
         """
         Copy and apply manifests to a cluster using copy_manifest.tf in a temporaryfolder.
@@ -872,6 +873,7 @@ class Swarmchestrate:
             master_ip: IP address of K3s master
             ssh_key_path: Path to SSH private key
             ssh_user: SSH username to connect to the master node
+            ssh_port: SSH port for the master node (defaults to 22)
         """
         # Dedicated folder for copy-manifest operations
         copy_dir = Path(self.output_dir) / "copy-manifest"
@@ -917,6 +919,7 @@ class Swarmchestrate:
                     f"-var=master_ip={master_ip}",
                     f"-var=ssh_private_key_path={ssh_key_path}",
                     f"-var=ssh_user={ssh_user}",
+                    f"-var=ssh_port={ssh_port}",
                 ],
                 cwd=str(copy_dir),
                 description="OpenTofu apply",
@@ -944,6 +947,7 @@ class Swarmchestrate:
                 "master_ip": "1.2.3.4",
                 "ssh_user": "ubuntu",
                 "ssh_private_key_path": "/path/to/key.pem",
+                "ssh_port": 22,
                 "namespace": "optional-namespace",
                 "secret_names": ["optional-name1", "optional-name2"]
             }
@@ -962,6 +966,7 @@ class Swarmchestrate:
         master_ip = cluster_config.get("master_ip")
         ssh_user = cluster_config.get("ssh_user")
         ssh_key_path = cluster_config.get("ssh_private_key_path")
+        ssh_port = cluster_config.get("ssh_port", 22)
         namespace = cluster_config.get("namespace", "default")
         secret_names = cluster_config.get("secret_names", [])
 
@@ -1009,6 +1014,7 @@ class Swarmchestrate:
                 f"-var=master_ip={master_ip}",
                 f"-var=ssh_user={ssh_user}",
                 f"-var=ssh_private_key_path={ssh_key_path}",
+                f"-var=ssh_port={ssh_port}",
                 f"-var=namespace={namespace}",
             ]
             if secret_names:

--- a/cluster_builder/templates/deploy_manifest.tf
+++ b/cluster_builder/templates/deploy_manifest.tf
@@ -4,6 +4,11 @@ variable "manifest_folder" {}
 variable "ssh_private_key_path" {}
 variable "master_ip" {}
 variable "ssh_user" {}
+variable "ssh_port" {
+  default     = 22
+  description = "SSH port for the master node. Use non-22 for DDNS/NAT setups (e.g. 10000)."
+}
+
 
 resource "null_resource" "copy_manifests" {
   connection {
@@ -11,6 +16,7 @@ resource "null_resource" "copy_manifests" {
     user        = var.ssh_user
     private_key = file(var.ssh_private_key_path)
     host        = var.master_ip
+    port        = var.ssh_port
   }
 
   # Copy manifest folder to a temporary location first

--- a/cluster_builder/templates/registry_secret.tf
+++ b/cluster_builder/templates/registry_secret.tf
@@ -18,6 +18,9 @@ variable "secret_names" {
 variable "master_ip" {}
 variable "ssh_user" {}
 variable "ssh_private_key_path" {}
+variable "ssh_port" {
+  default = 22
+}
 variable "namespace" {
   default = "default"
 }
@@ -30,6 +33,7 @@ resource "null_resource" "docker_registry_secrets" {
     host        = var.master_ip
     user        = var.ssh_user
     private_key = file(var.ssh_private_key_path)
+    port        = var.ssh_port
   }
 
   provisioner "remote-exec" {

--- a/demo/deploy-manifest.py
+++ b/demo/deploy-manifest.py
@@ -17,4 +17,5 @@ Swarmchestrate(template_dir="templates", output_dir="output").deploy_manifests(
     master_ip=cfg["master_ip"],
     ssh_key_path=cfg["ssh_key_path"],
     ssh_user=cfg["ssh_user"],
+    ssh_port=cfg.get("ssh_port", 22),
 )

--- a/demo/manifest-config.json.sample
+++ b/demo/manifest-config.json.sample
@@ -2,5 +2,6 @@
   "manifest_folder": "/workspaces/cluster-builder/manifest",
   "master_ip": "193.225.250.17",
   "ssh_key_path": "/workspaces/cluster-builder/scripts/g.pem",
-  "ssh_user": "ubuntu"
+  "ssh_user": "ubuntu",
+  "ssh_port": 22
 }

--- a/demo/registry.py
+++ b/demo/registry.py
@@ -11,6 +11,7 @@ registry_config = {
     "master_ip": "34.201.107.206",
     "ssh_user": "ec2-user",
     "ssh_private_key_path": "/workspaces/cluster-builder/output/g.pem",
+    "ssh_port": 22,
     "secret_names": ["test"],
 }
 


### PR DESCRIPTION
This PR updates manifest deployment plus registry secret creation to accept optional [ssh_port] (default 22), including related demo/config updates so non-default SSH port environments work consistently.